### PR TITLE
Change ButtonTransmit Example Payload to JSON string

### DIFF
--- a/examples/ButtonTransmit/ButtonTransmit.ino
+++ b/examples/ButtonTransmit/ButtonTransmit.ino
@@ -52,6 +52,10 @@ String message2 = "World!";
 
 void loop() {
   while(button_pushed) {
+      // Important! It is recommended to use a more efficient
+      // data representation and/or serialization technique when 
+      // transmitting data in a production setting.
+
       // Prepare Payload Buffer
       String full_msg = "{\"value1\":" + String(counter) + ",\"value2\":\"" + message1 + "\",\"value3\":\"" + message2 + "\"}";
       uint8_t msg_len = full_msg.length();

--- a/examples/ButtonTransmit/ButtonTransmit.ino
+++ b/examples/ButtonTransmit/ButtonTransmit.ino
@@ -3,8 +3,8 @@
 #include "LongFi.h"
 
 // set OUI and device_id to work with LongFi routing
-const uint32_t oui = 1;
-const uint16_t device_id = 11;
+const uint32_t oui = 1234;
+const uint16_t device_id = 99;
 const uint8_t preshared_key[16] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16};
 
 #ifdef _VARIANT_ARDUINO_STM32_
@@ -23,21 +23,22 @@ LongFi LongFi(LongFi::RadioType::SX1276, RADIO_RESET_PIN, RADIO_SS_PIN, RADIO_DI
 static boolean volatile button_pushed = false;
 
 void setup() {
+  // Configure Debug Print and LED
   Serial.begin(9600);
   Serial.println("Setup Start");
   pinMode(LED, OUTPUT);
-
+  // Assign Radio SPI Pins
   SPI.setMOSI(RADIO_MOSI_PIN);
   SPI.setMISO(RADIO_MISO_PIN);
   SPI.setSCLK(RADIO_SCLK_PIN);
   SPI.setSSEL(RADIO_SS_PIN);
   SPI.begin();
-
+  // Init LongFi
   LongFi.init(oui, device_id, preshared_key);
-  Serial.println("Setup Complete");
-
+  // Configure User Button 
   pinMode(USER_BUTTON, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(USER_BUTTON), push_button_ISR, HIGH);
+  Serial.println("Setup Complete");
 }
 
 void push_button_ISR(){
@@ -46,22 +47,30 @@ void push_button_ISR(){
 
 uint8_t buf[128];
 uint8_t counter = 1;
-String message = "hello";
+String message1 = "Hello";
+String message2 = "World!";
+
 void loop() {
   while(button_pushed) {
-      String full_msg = "|" + String(counter) + ": " + message+ "|";
-      uint8_t msg_len = sizeof(full_msg) - 1;
-      full_msg.getBytes(buf, msg_len);
-      Serial.println("Button press #: "+String(counter));
+      // Prepare Payload Buffer
+      String full_msg = "{\"value1\":" + String(counter) + ",\"value2\":\"" + message1 + "\",\"value3\":\"" + message2 + "\"}";
+      uint8_t msg_len = full_msg.length();
+      memcpy(buf, full_msg.c_str(), msg_len);
+      // Debug Prints
+      Serial.println("Payload: " + full_msg);
+      Serial.println("Length: " + String(msg_len));
+      Serial.println("Button press #: " + String(counter));
       // Turn LED ON to indicate beginning of TX
       digitalWrite(LED, HIGH);
-      // send blocks until complete
+      // Send Payload Buffer 
       LongFi.send(buf, msg_len);
       // Turn LED OFF to indicate completion of TX
       digitalWrite(LED, LOW);
+      // Reset Button Flag
       noInterrupts();
       button_pushed = false;
       interrupts();
+      // Increment Counter
       counter++;
   }
 }


### PR DESCRIPTION
This PR changes the LongFi payload in the ButtonTransmit example to use a JSON string. This change should make it easier for those wanting to use the payload on the receiving end to easily parse it. 

This is not the most efficient way to transmit data using LongFi, but we are opting for simplicity in these examples to help users get started.