### PR TITLE
Update ButtonTransmit Example with Compact Data Payload

### DIFF
--- a/examples/ButtonTransmit/ButtonTransmit.ino
+++ b/examples/ButtonTransmit/ButtonTransmit.ino
@@ -20,6 +20,10 @@ LongFi LongFi(LongFi::RadioType::SX1276, RADIO_RESET_PIN, RADIO_SS_PIN, RADIO_DI
 #endif
 static boolean volatile button_pushed = false;
 
+// !! Important !!
+// Be aware that endianness will
+// depend on your target device and the 
+// receiving device of this packet payload.
 struct LongFiPayload_t{
   uint32_t value1;
   int16_t value2;


### PR DESCRIPTION
This PR improves upon the current ButtonTransmit example sketch by only sending the data values we care about in the payload. There is still a small amount of room for packing the payload even more, but it would increase the complexity of the receiving side and I believe the current balance is sufficient. 