### PR TITLE
RFM95 functionality

### DIFF
--- a/longfi-us915/longfi-us915.ino
+++ b/longfi-us915/longfi-us915.ino
@@ -267,7 +267,7 @@ void setup() {
 
     LMIC_setLinkCheckMode(0);
     LMIC_setDrTxpow(DR_SF7,14);
-    LMIC_selectSubBand(1);
+    LMIC_selectSubBand(6);
 
     // Start job (sending automatically starts OTAA too)
     do_send(&sendjob);


### PR DESCRIPTION
The only change needed to make the RFM95 work is to change from US TTN subband to Helium subband